### PR TITLE
clean up unmatched right single quotes at the end

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,8 +80,22 @@ function appendPlurals(str) {
   return str.replace(/(s)'(\s|$)/gi, `$1${a}$2`);
 }
 
-function unmatchedQuotes(str) {
+/**
+ * curl any unmatched left quotes
+ * @param {string} str
+ * @returns {string}
+ */
+function unmatchedLeftQuotes(str) {
   return str.replace(/(^|\s)['"](.*?)/gi, `$1${l}$2`);
+}
+
+/**
+ * finally, curl any unmatched right quotes
+ * @param {string} str
+ * @returns {string}
+ */
+function unmatchedRightQuotes(str) {
+  return str.replace(/(.*?)['"](\s|$)/gi, `$1${r}$2`);
 }
 
 export default function (str) {
@@ -92,6 +106,7 @@ export default function (str) {
   str = quote(str);
   str = appendWhitelist(str);
   str = appendPlurals(str);
-  str = unmatchedQuotes(str);
+  str = unmatchedLeftQuotes(str);
+  str = unmatchedRightQuotes(str);
   return str;
 }

--- a/test.js
+++ b/test.js
@@ -48,7 +48,7 @@ describe('headline-quotes', function () {
 
   it('renders single quotes in headlines', function () {
     expect(quote('\'Hello World\' Reports New AI')).to.equal(`${l}Hello World${r} Reports New AI`);
-    expect(quote('Donald Trump Calls Hillary Clinton the \'Devil\'')).to.equal(`Donald Trump Calls Hillary Clinton the ${l}Devil${r}`)
+    expect(quote('Hackers Program Terrifying Message Into Highway Sign: \'Poop\'')).to.equal(`Hackers Program Terrifying Message Into Highway Sign: ${l}Poop${r}`)
   });
 
   it('renders double quotes in headlines', function () {

--- a/test.js
+++ b/test.js
@@ -48,6 +48,7 @@ describe('headline-quotes', function () {
 
   it('renders single quotes in headlines', function () {
     expect(quote('\'Hello World\' Reports New AI')).to.equal(`${l}Hello World${r} Reports New AI`);
+    expect(quote('Donald Trump Calls Hillary Clinton the \'Devil\'')).to.equal(`Donald Trump Calls Hillary Clinton the ${l}Devil${r}`)
   });
 
   it('renders double quotes in headlines', function () {


### PR DESCRIPTION
There are certain situations where unmatched right quotes weren't being caught, so we're doing a final pass after everything else to curl them.
